### PR TITLE
Correctly save team info when authorising a Slack app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /**
- * botkit-storage-mongo - MongoDB driver for Botkit
+ * botkit-storage-dynamodb - DynamoDB driver for Botkit
  *
  * @param  {Object} config Must contain a dynamoRegion, dynamoAccessKey,
  *         dynamoAccessSecret properties, optionally dynamoTable (defaults to botkit)

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,8 @@ function getStorage(db, table, type) {
 }
 
 function removeTypeAndID(data) {
-    delete data.id;
-    delete data.type;
-    return data;
+    var copy = JSON.parse(JSON.stringify(data));
+    delete copy.id;
+    delete copy.type;
+    return copy;
 }


### PR DESCRIPTION
This fixes a bug when authorising a Slack app. In the `/oauth` endpoint, Botkit saves team info twice, first [here](https://github.com/howdyai/botkit/blob/53d6a1fc502cc824788390218331ba52f87e3f65/lib/SlackBot.js#L572) and then [there](https://github.com/howdyai/botkit/blob/53d6a1fc502cc824788390218331ba52f87e3f65/lib/SlackBot.js#L595), after getting the bot's name.

The first call works fine, but the second one fails because the `id` and `type` properties are no longer on the `team` object (since it is passed by reference). To prevent this, we must ensure we're using a copy of the data, hence the `JSON.stringify / JSON.parse` trick.

This method of cloning should be safe for our purposes, since the objects we want to clone should only contain data in the first place, and no methods (also, looking at [botkit's simple storage option](https://github.com/howdyai/botkit/blob/53d6a1fc502cc824788390218331ba52f87e3f65/lib/storage/simple_storage.js#L25), we can see that it uses `jfs`, which itself relies on stringifying and parsing JSON to write / read data)